### PR TITLE
Java 8 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,12 @@ subprojects {
 
 // Task to create a single 'fat' JAR including all subprojects
 task uberJar(type: ShadowJar) {
+
+    // Relocate important dependencies to avoid any collisions at runtime
+    relocate 'org.yaml.snakeyaml', 'host.bloom.ab.dependencies.snakeyml'
+    relocate 'com.google.gson', 'host.bloom.ab.dependencies.gson'
+    relocate 'org.apache.commons', 'host.bloom.ab.dependencies.apache.commons'
+
     // Set the output file name and location
     archiveFileName = "${project.ext.pluginName}-${project.ext.pluginVersion}.jar"
 

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -6,6 +6,10 @@ repositories {
     }
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs.addAll(['--release', '8'])
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,7 @@
+tasks.withType(JavaCompile) {
+    options.compilerArgs.addAll(['--release', '8'])
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/common/src/main/java/host/bloom/ab/common/AbstractPlugin.java
+++ b/common/src/main/java/host/bloom/ab/common/AbstractPlugin.java
@@ -6,6 +6,7 @@ import host.bloom.ab.common.utils.Logger;
 import host.bloom.ab.common.utils.Scheduler;
 import host.bloom.ab.common.utils.UpdateChecker;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,12 +35,12 @@ public interface AbstractPlugin {
     default void afterStartup() {
 
         // Ensure it's on a supported port
-        List<Integer> supportedPorts = List.of(25565, 25566, 25567);
+        List<Integer> supportedPorts = Arrays.asList(25565, 25566, 25567);
         if (!supportedPorts.contains(this.getPort())) {
             throw new RuntimeException("The server is not using a supported port! Please ensure it's using one of the following ports, and restart: " + supportedPorts.stream().map(String::valueOf).collect(Collectors.joining(", ")));
         }
 
-        this.getABLogger().info("Successfully loaded version: v%s, location: %s!".formatted(this.getVersion(), this.getABConfig().location.getDisplayName()));
+        this.getABLogger().info("Successfully loaded version: v" + this.getVersion() + ", location: " + this.getABConfig().location.getDisplayName() + "!");
 
         // Check for new updates in the background
         UpdateChecker.handle(this);

--- a/common/src/main/java/host/bloom/ab/common/commands/Handler.java
+++ b/common/src/main/java/host/bloom/ab/common/commands/Handler.java
@@ -5,6 +5,7 @@ import host.bloom.ab.common.commands.sub.Force;
 import host.bloom.ab.common.commands.sub.ForceStop;
 import host.bloom.ab.common.commands.sub.Set;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +66,7 @@ public class Handler {
         if (!sender.hasPermission("bab.admin")) return Collections.emptyList();
 
         // Return the subcommands
-        if (args.length <= 1) return commands.keySet().stream().toList();
+        if (args.length <= 1) return new ArrayList<>(commands.keySet());
 
         // See if it's a command
         SubCommand command = commands.get(args[0].toLowerCase());

--- a/common/src/main/java/host/bloom/ab/common/commands/sub/Set.java
+++ b/common/src/main/java/host/bloom/ab/common/commands/sub/Set.java
@@ -8,6 +8,7 @@ import host.bloom.ab.common.utils.Utils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -121,7 +122,7 @@ public class Set implements SubCommand {
     @Override
     public List<String> getTabCompletion(String[] args) {
         if (args.length == 2) {
-            return List.of("maxjps", "duration", "location");
+            return Arrays.asList("maxjps", "duration", "location");
         }
 
         if (args.length == 3) {

--- a/common/src/main/java/host/bloom/ab/common/utils/UpdateChecker.java
+++ b/common/src/main/java/host/bloom/ab/common/utils/UpdateChecker.java
@@ -2,15 +2,7 @@ package host.bloom.ab.common.utils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-
 import host.bloom.ab.common.AbstractPlugin;
-import host.bloom.ab.common.utils.GitHubRelease;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -19,13 +11,9 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.stream.Collectors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.lang.reflect.Type;
-
 public class UpdateChecker {
 
-	static Gson gson = new GsonBuilder().create();
+    static Gson gson = new GsonBuilder().create();
 
     public static void handle(AbstractPlugin plugin) {
         if (!plugin.getABConfig().checkForUpdates) return;

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -8,6 +8,10 @@ dependencies {
     annotationProcessor velocityJar
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs.addAll(['--release', '8'])
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/waterfall/build.gradle
+++ b/waterfall/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     compileOnly files('libs/waterfall-1.20-562.jar')
 }
 
+// We explicitly skip --release 8 for this, since unsafe would fail
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
There were a few missing pieces to support Java 8:

1. Without using the `--release 8` flag, we missed some new language features which error at runtime
2. Some packages conflict with older Spigot/Paper versions, so we need to relocate them
3. After fixing the first point, the unsafe reflection logic does not build correctly. ATM, I could not find a better way, such as how Velocity lets you swap out the channel, so we just skip Waterfall for this flag. All of our runtime Java versions will work with this fine. 
  More info: https://github.com/Bloom-host/Issues/issues/55

This should allow 1.8.x - 1.20.x and Java 8 - Java 17 support