### PR TITLE
Uses the correct permission in velocity/waterfall on join.

### DIFF
--- a/bukkit/src/main/java/host/bloom/ab/bukkit/BukkitLoginListener.java
+++ b/bukkit/src/main/java/host/bloom/ab/bukkit/BukkitLoginListener.java
@@ -21,7 +21,7 @@ public class BukkitLoginListener implements Listener {
 
         Player player = e.getPlayer();
 
-        if (player.hasPermission("bab.admin.actionbar.onjoin")) {
+        if (player.hasPermission("bab.admin.actionbar.autoenable")) {
             this.plugin.getManager().addSeer(player.getUniqueId());
         }
     }

--- a/bukkit/src/main/java/host/bloom/ab/bukkit/BukkitLoginListener.java
+++ b/bukkit/src/main/java/host/bloom/ab/bukkit/BukkitLoginListener.java
@@ -21,7 +21,7 @@ public class BukkitLoginListener implements Listener {
 
         Player player = e.getPlayer();
 
-        if (player.hasPermission("bab.admin.actionbar.autoenable")) {
+        if (player.hasPermission("bab.admin.actionbar.onjoin")) {
             this.plugin.getManager().addSeer(player.getUniqueId());
         }
     }

--- a/velocity/src/main/java/host/bloom/ab/velocity/VelocityLoginListener.java
+++ b/velocity/src/main/java/host/bloom/ab/velocity/VelocityLoginListener.java
@@ -39,7 +39,7 @@ public class VelocityLoginListener {
     public void onJoin(LoginEvent event) {
         Player player = event.getPlayer();
 
-        if (player.hasPermission("bab.admin.actionbar.autoenable")) {
+        if (player.hasPermission("bab.admin.actionbar.onjoin")) {
             this.plugin.getManager().addSeer(player.getUniqueId());
         }
     }

--- a/waterfall/src/main/java/host/bloom/ab/waterfall/WaterfallLoginListener.java
+++ b/waterfall/src/main/java/host/bloom/ab/waterfall/WaterfallLoginListener.java
@@ -19,7 +19,7 @@ public class WaterfallLoginListener implements Listener {
     public void onJoin(PostLoginEvent event) {
         ProxiedPlayer player = event.getPlayer();
 
-        if (player.hasPermission("bab.admin.actionbar.autoenable")) {
+        if (player.hasPermission("bab.admin.actionbar.onjoin")) {
             this.manager.addSeer(player.getUniqueId());
         }
     }


### PR DESCRIPTION
The permission used in the velocity/waterfall module was `bab.admin.actionbar.autoenable`. I was doing something else to help permission plugins and noticed this was wrong.

Velocity/Waterfall module now use bab.admin.actionbar.onjoin as described in the changelog.